### PR TITLE
[BOTS-2355] escape single quote at the beginning of the string

### DIFF
--- a/bigquery/query_builder.py
+++ b/bigquery/query_builder.py
@@ -2,7 +2,7 @@ import re
 
 from logging import getLogger, NullHandler
 
-UNESCAPED_QUOTE = r"([^\\])'"
+UNESCAPED_QUOTE = r"([^\\])'|(^)'"
 
 logger = getLogger(__name__)
 logger.addHandler(NullHandler())
@@ -461,4 +461,7 @@ def _replace_quote_with(match):
     >>> match is None
     True
     """
+
+    if match.group(0)[0] == '\'':
+        return "\\'"
     return match.group(0)[0] + r"\'"

--- a/bigquery/tests/test_query_builder.py
+++ b/bigquery/tests/test_query_builder.py
@@ -1009,6 +1009,7 @@ class TestParameterizedQuery(unittest.TestCase):
     def setUp(self):
         self.input = "SELECT x FROM {data_set} WHERE value = '{value}'"
         self.non_string_input = "SELECT x FROM {data_set} WHERE value = {value}"
+        self.in_statement_input = "SELECT x FROM {data_set} WHERE value IN ({value})"
 
     def test_bind_arguments_with_single_quotes(self):
         from bigquery.query_builder import ParameterizedQuery
@@ -1085,4 +1086,20 @@ class TestParameterizedQuery(unittest.TestCase):
         self.assertEqual(
             query_statement,
             "SELECT x FROM table WHERE value = True"
+        )
+
+    def test_bind_string_arguments_strating_with_single_quote(self):
+        from bigquery.query_builder import ParameterizedQuery
+
+        query = ParameterizedQuery(self.in_statement_input)
+
+        query_statement = query.bind(data_set='table',
+                                     value="'a', 'b'")
+
+        print('\n\nquery_statement\n\n')
+        print(query_statement)
+
+        self.assertEqual(
+            query_statement,
+            "SELECT x FROM table WHERE value IN (\\'a\\', \\'b\\')"
         )

--- a/bigquery/tests/test_query_builder.py
+++ b/bigquery/tests/test_query_builder.py
@@ -1096,9 +1096,6 @@ class TestParameterizedQuery(unittest.TestCase):
         query_statement = query.bind(data_set='table',
                                      value="'a', 'b'")
 
-        print('\n\nquery_statement\n\n')
-        print(query_statement)
-
         self.assertEqual(
             query_statement,
             "SELECT x FROM table WHERE value IN (\\'a\\', \\'b\\')"


### PR DESCRIPTION
## What does this PR do?
Fixes error when escaping single quotes in queries

## What was the issue?
the regular expression used to match unescaped single quotes (`([^\\])`) was not matching single quotes at the beginning of the string. so `'facebook', 'webchat'` resulted in `'facebook\\', \\'webchat\\'`